### PR TITLE
Fix compatibility with ClangCL

### DIFF
--- a/Plugins/GMP/Source/GMP/Shared/UnrealCompatibility.h
+++ b/Plugins/GMP/Source/GMP/Shared/UnrealCompatibility.h
@@ -317,7 +317,7 @@ clang:
 MSVC:
 	const char *__cdecl ITS::TypeStr<{type}>(void)
 */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define Z_ITS_TYPE_NAME_ __FUNCSIG__
 template<typename Type>
 constexpr uint32 FRONT_SIZE = sizeof("const char *__cdecl ITS::TypeStr<") - 1u + (std::is_enum<Type>::value ? 5u : (std::is_class<Type>::value ? 6u : 0u));


### PR DESCRIPTION
ClangCL on windows also defines _MSC_VER, which results in incorrect Z_ITS_TYPE_NAME_ impl.
Tested clang-cl version: 15.0.6